### PR TITLE
Stabilize Prisma client and admin gating

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,12 +1,22 @@
 // src/lib/prisma.ts
 import { PrismaClient } from "@prisma/client";
 
-const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
+
+const datasourceUrl =
+  process.env.DATABASE_URL &&
+  // Disable prepared statements for short-lived connections
+  `${process.env.DATABASE_URL}${
+    process.env.DATABASE_URL.includes("?") ? "&" : "?"
+  }pgbouncer=true`;
 
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    log: ["warn", "error"],
+    log: ["query"],
+    ...(datasourceUrl ? { datasourceUrl } : {}),
   });
 
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}


### PR DESCRIPTION
## Summary
- ensure Prisma uses a single global client and disables prepared statements for pooled connections
- simplify admin-role middleware to query profile via Prisma instead of requiring Supabase service role

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e9bad7af8832a99171ae033f169ca